### PR TITLE
mark entity as mappedSuperclass

### DIFF
--- a/Entity/User.php
+++ b/Entity/User.php
@@ -10,13 +10,12 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 
 /**
- * @ORM\Table(name="user")
- * @ORM\Entity
+ * @ORM\MappedSuperclass
  * @UniqueEntity("email")
  * @UniqueEntity("username")
  */
 
-class User implements UserInterface, \Serializable
+abstract class User implements UserInterface, \Serializable
 {
     /**
      * @ORM\Column(type="integer")


### PR DESCRIPTION
To be able to extend the User Entity in my own Project, the base user class have to be marked as MappedSuperclass
see https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/inheritance-mapping.html#mapped-superclasses